### PR TITLE
Feature/await transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
+.npmrc
 coverage
+dist
 node_modules
 *.tmp
 tmp
-.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/orejs",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-rights-exchange/orejs",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Orejs is a Javascript helper library to provide simple high-level access to the ore-protocol. Orejs uses eosJS as a wrapper to the EOS blockchain.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -157,9 +157,10 @@ async function createOreAccountWithKeys(activePublicKey, ownerPublicKey, options
   let transaction;
   if (confirm) {
     transaction = await this.confirmTransaction(() => newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options));
+  } else {
+    transaction = await newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options);
   }
-
-  transaction = await newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options);
+  
   return {
     oreAccountName,
     transaction,

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -173,7 +173,7 @@ async function generateOreAccountAndKeys(ownerPublicKey, options = {}) {
   const {
     oreAccountName,
     transaction,
-  } = await createOreAccountWithKeys.bind(this)(keys.publicKeys.active, ownerPublicKey, options);
+  } = await createOreAccountWithKeys.bind(this)(keys.publicKeys.active, ownerPublicKey, options, true);
 
   return {
     keys,

--- a/src/accounts.js
+++ b/src/accounts.js
@@ -156,11 +156,10 @@ async function createOreAccountWithKeys(activePublicKey, ownerPublicKey, options
   const oreAccountName = options.oreAccountName || generateAccountName();
   let transaction;
   if (confirm) {
-    transaction = await this.confirmTransaction(() => newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options));
+    transaction = await this.awaitTransaction(() => newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options));
   } else {
     transaction = await newAccountTransaction.bind(this)(oreAccountName, ownerPublicKey, activePublicKey, options);
   }
-  
   return {
     oreAccountName,
     transaction,

--- a/src/eos.js
+++ b/src/eos.js
@@ -34,7 +34,7 @@ async function awaitTransaction(func, blocksToCheck = 10, checkInterval = 200) {
   const transaction = await func();
   // check the head block...
   let latestBlock = await this.getHeadBlock();
-  const initialBlockId = latestBlock.block_num;
+  const initialBlockNum = latestBlock.block_num;
   if (hasTransaction(latestBlock, transaction.transaction_id)) {
     return transaction;
   }
@@ -45,9 +45,9 @@ async function awaitTransaction(func, blocksToCheck = 10, checkInterval = 200) {
       if (hasTransaction(latestBlock, transaction.transaction_id)) {
         clearInterval(intConfirm);
         resolve(transaction);
-      } else if (latestBlock.block_num >= initialBlockId + blocksToCheck) {
+      } else if (latestBlock.block_num >= initialBlockNum + blocksToCheck) {
         clearInterval(intConfirm);
-        reject(new Error('Transaction Confirmation Timeout'));
+        reject(new Error(`Transaction Confirmation Timeout @ Block Num: ~${initialBlockNum}`));
       }
     }, checkInterval);
   });

--- a/src/eos.js
+++ b/src/eos.js
@@ -25,14 +25,15 @@ function contractOptions(accountName, permission = 'active') {
 
 /* Public */
 
-// eosjs only confirms that transactions have been accepted
-// this confirms that the transaction has been written to the chain
-// by checking block produced immediately after the transaction
-async function confirmTransaction(func, blocksToCheck = 10, checkInterval = 500) {
+// NOTE: Use this to await for transactions to be added to a block
+// Useful, when committing sequential transactions with inter-dependencies
+// NOTE: This does NOT confirm that the transaction is irreversible, aka finalized
+// NOTE: Time between blocks isn't always 500ms, so keep the checkInterval lower than 500ms
+async function awaitTransaction(func, blocksToCheck = 10, checkInterval = 200) {
   // make the transaction...
   const transaction = await func();
   // check the head block...
-  let latestBlock = await this.getLatestBlock();
+  let latestBlock = await this.getHeadBlock();
   const initialBlockId = latestBlock.block_num;
   if (hasTransaction(latestBlock, transaction.transaction_id)) {
     return transaction;
@@ -40,7 +41,7 @@ async function confirmTransaction(func, blocksToCheck = 10, checkInterval = 500)
   // check following blocks for the transaction id...
   return new Promise((resolve, reject) => {
     const intConfirm = setInterval(async () => {
-      latestBlock = await this.getLatestBlock();
+      latestBlock = await this.getHeadBlock();
       if (hasTransaction(latestBlock, transaction.transaction_id)) {
         clearInterval(intConfirm);
         resolve(transaction);
@@ -91,7 +92,7 @@ async function getAllTableRows(params, key_field = 'id', json = true) {
   return results.rows;
 }
 
-async function getLatestBlock() {
+async function getHeadBlock() {
   const info = await this.eos.getInfo({});
   const block = await this.eos.getBlock(info.head_block_num);
   return block;
@@ -109,11 +110,11 @@ async function checkPubKeytoAccount(account, publicKey) {
 }
 
 module.exports = {
-  confirmTransaction,
+  awaitTransaction,
   contract,
   findOne,
   getAllTableRows,
-  getLatestBlock,
+  getHeadBlock,
   hasTransaction,
   tableKey,
   checkPubKeytoAccount,

--- a/src/eos.js
+++ b/src/eos.js
@@ -97,7 +97,7 @@ async function getAllTableRows(params, key_field = 'id', json = true) {
 
 async function getLatestBlock() {
   const info = await this.eos.getInfo({});
-  const block = await this.eos.getBlock(info.last_irreversible_block_num);
+  const block = await this.eos.getBlock(info.head_block_num);
   return block;
 }
 

--- a/src/eos.js
+++ b/src/eos.js
@@ -47,7 +47,7 @@ async function awaitTransaction(func, blocksToCheck = 10, checkInterval = 200) {
         resolve(transaction);
       } else if (latestBlock.block_num >= initialBlockNum + blocksToCheck) {
         clearInterval(intConfirm);
-        reject(new Error(`Transaction Confirmation Timeout @ Block Num: ~${initialBlockNum}`));
+        reject(new Error(`Await Transaction Timeout: Waited for ${blocksToCheck} blocks (${blocksToCheck / 2} seconds) starting with block num: ${initialBlockNum}. This does not mean the transaction failed just that the transaction wasn't found in a block before timeout`));
       }
     }, checkInterval);
   });

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -118,7 +118,7 @@ async function createOfferInstrument(oreAccountName, offerData, confirm = false)
   };
   const contract = await this.eos.contract(APIM_CONTRACT_NAME, options);
   if (confirm) {
-    return this.confirmTransaction(() => contract.publishapi(oreAccountName, offerData.issuer, offerData.security_type,
+    return this.awaitTransaction(() => contract.publishapi(oreAccountName, offerData.issuer, offerData.security_type,
       offerData.mutability, offerData.api_params, offerData.additional_url_params,
       offerData.parameter_rules, offerData.instrument_template, offerData.start_time,
       offerData.end_time, offerData.override_offer_id, options));
@@ -142,7 +142,7 @@ async function createVoucherInstrument(creator, buyer, offerId, overrideVoucherI
   };
   const contract = await this.eos.contract(APIM_CONTRACT_NAME, options);
   if (confirm) {
-    return this.confirmTransaction(() => contract.licenseapi(creator, buyer, offerId, offerTemplate, overrideVoucherId, options));
+    return this.awaitTransaction(() => contract.licenseapi(creator, buyer, offerId, offerTemplate, overrideVoucherId, options));
   }
   contract.licenseapi(creator, buyer, offerId, offerTemplate, overrideVoucherId, options);
   return this;

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -5,7 +5,9 @@ const ecc = require('eosjs-ecc');
 const {
   constructOrejs,
   mockGetAccount,
-  mockTransaction,
+  mockGetInfo,
+  mockGetBlock,
+  mockGetTransaction,
 } = require('./helpers/orejs');
 
 describe('account', () => {
@@ -18,24 +20,35 @@ describe('account', () => {
   describe('createOreAccount', () => {
     let spyTransaction;
     let spyAccount;
+    let spyInfo;
+    let spyBlock;
+    let transaction;
+    let info;
+    let block;
     beforeEach(() => {
       mockGetAccount(orejs);
-      mockTransaction(orejs);
+      transaction = mockGetTransaction(orejs);
+      info = mockGetInfo(orejs);
+      block = mockGetBlock(orejs, { block_num: info.head_block_num, transactions: [{ trx: { id: transaction.transaction_id } }] });
       spyTransaction = jest.spyOn(orejs.eos, 'transaction');
       spyAccount = jest.spyOn(orejs.eos, 'getAccount');
+      spyInfo = jest.spyOn(orejs.eos, 'getInfo');
+      spyBlock = jest.spyOn(orejs.eos, 'getBlock');
     });
 
     test('returns a new account', async () => {
       const account = await orejs.createOreAccount(WALLET_PASSWORD, ORE_OWNER_ACCOUNT_KEY);
       expect(spyTransaction).toHaveBeenNthCalledWith(2, expect.any(Function));
       expect(spyAccount).toHaveBeenCalledWith(expect.any(String));
+      expect(spyInfo).toHaveBeenCalledWith({});
+      expect(spyBlock).toHaveBeenCalledWith(block.block_num);
       expect(account).toEqual({
         verifierAuthKey: expect.any(String),
         verifierAuthPublicKey: expect.any(String),
         oreAccountName: expect.stringMatching(/[a-z1-5\.]{12}/),
         privateKey: expect.any(String),
         publicKey: expect.any(String),
-        transaction: expect.any(Function),
+        transaction: transaction,
       });
       expect(ecc.privateToPublic(orejs.decrypt(account.privateKey, WALLET_PASSWORD))).toEqual(account.publicKey);
       expect(ecc.privateToPublic(account.verifierAuthKey)).toEqual(account.verifierAuthPublicKey);

--- a/test/eos.test.js
+++ b/test/eos.test.js
@@ -73,7 +73,7 @@ describe('token', () => {
           await setTimeout(() => true, 10);
           return transaction;
         }, 2, 10);
-        expect(result).rejects.toThrow(/unauthorized/);
+        expect(result).rejects.toThrow();
       });
     });
   });

--- a/test/eos.test.js
+++ b/test/eos.test.js
@@ -7,6 +7,10 @@ const {
 } = require('./helpers/fetch');
 const {
   constructOrejs,
+  mockGetAccount,
+  mockGetInfo,
+  mockGetBlock,
+  mockGetTransaction,
 } = require('./helpers/orejs');
 
 describe('token', () => {
@@ -30,6 +34,47 @@ describe('token', () => {
       const blockNum = await orejs.getHeadBlock();
       expectFetch(`${ORE_NETWORK_URI}/v1/chain/get_info`, `${ORE_NETWORK_URI}/v1/chain/get_block`);
       expect(JSON.stringify(blockNum)).toEqual(block[0]);
+    });
+  });
+
+  describe('awaitTransaction', () => {
+    let transaction;
+    let info;
+    let block;
+    let spyInfo;
+    let spyBlock;
+    beforeAll(() => {
+      transaction = mockGetTransaction(orejs);
+      info = mockGetInfo(orejs);
+      block = mockGetBlock(orejs, { block_num: info.head_block_num, transactions: [{ trx: { id: transaction.transaction_id } }] });
+      spyInfo = jest.spyOn(orejs.eos, 'getInfo');
+      spyBlock = jest.spyOn(orejs.eos, 'getBlock');
+    });
+
+    test('returns the transaction', async () => {
+      await orejs.awaitTransaction(async () => {
+        await setTimeout(() => true, 10);
+        return transaction;
+      }, 10, 10);
+      expect(spyInfo).toHaveBeenCalledWith({});
+      expect(spyBlock).toHaveBeenCalledWith(block.block_num);
+    });
+
+    describe('when the transaction is not found', () => {
+      beforeAll(() => {
+        jest.clearAllMocks();
+        transaction = mockGetTransaction(orejs);
+        info = mockGetInfo(orejs);
+        block = mockGetBlock(orejs, { block_num: info.head_block_num, transactions: [{ trx: { id: transaction.transaction_id + 1 } }] });
+      });
+
+      test('throws an error with the block number', async () => {
+        const result = orejs.awaitTransaction(async () => {
+          await setTimeout(() => true, 10);
+          return transaction;
+        }, 2, 10);
+        expect(result).rejects.toThrow(/unauthorized/);
+      });
     });
   });
 

--- a/test/eos.test.js
+++ b/test/eos.test.js
@@ -16,7 +16,7 @@ describe('token', () => {
     orejs = constructOrejs();
   });
 
-  describe('getLatestBlock', () => {
+  describe('getHeadBlock', () => {
     let block;
 
     beforeEach(() => {
@@ -27,7 +27,7 @@ describe('token', () => {
     });
 
     test('returns the latest block', async () => {
-      const blockNum = await orejs.getLatestBlock();
+      const blockNum = await orejs.getHeadBlock();
       expectFetch(`${ORE_NETWORK_URI}/v1/chain/get_info`, `${ORE_NETWORK_URI}/v1/chain/get_block`);
       expect(JSON.stringify(blockNum)).toEqual(block[0]);
     });

--- a/test/helpers/fetch.js
+++ b/test/helpers/fetch.js
@@ -14,7 +14,7 @@ function mock(body, status = 200) {
   ];
 }
 
-function mockAccount() {
+function mockAccount(account = {}) {
   return mock([{
     account_name: 'y4dcmrzgiyte',
     cpu_limit: {
@@ -72,10 +72,11 @@ function mockAccount() {
       ram_bytes: 8150,
     },
     voter_info: null,
+    ...account,
   }]);
 }
 
-function mockBlock() {
+function mockBlock(block = {}) {
   return mock([{
     timestamp: '2018-07-30T14:24:24.000',
     producer: 'eosio',
@@ -92,10 +93,11 @@ function mockBlock() {
     id: '00090a0384aa271b99b94d25a3d069c4387625e972d05c21ffa17180d1f09ec2',
     block_num: 592387,
     ref_block_prefix: 625850777,
+    ...block,
   }]);
 }
 
-function mockInfo() {
+function mockInfo(info = {}) {
   return mock([{
     server_version: '75635168',
     chain_id: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
@@ -109,6 +111,7 @@ function mockInfo() {
     virtual_block_net_limit: 1048576000,
     block_cpu_limit: 199900,
     block_net_limit: 1048576,
+    ...info,
   }]);
 }
 
@@ -158,6 +161,13 @@ function mockInstruments(instruments = [{}]) {
   });
 }
 
+function mockTransaction(transaction = {}) {
+  return {
+    transaction_id: '0',
+    ...transaction,
+  };
+}
+
 module.exports = {
   expectFetch,
   mock,
@@ -166,4 +176,5 @@ module.exports = {
   mockInfo,
   mockInstrument,
   mockInstruments,
+  mockTransaction,
 };

--- a/test/helpers/orejs.js
+++ b/test/helpers/orejs.js
@@ -7,7 +7,9 @@ const {
 } = require('../../src');
 const {
   mockAccount,
+  mockBlock,
   mockInfo,
+  mockTransaction,
 } = require('./fetch');
 
 function constructOrejs() {
@@ -39,10 +41,10 @@ function mockContract() {
   return contract;
 }
 
-function mockGetAccount(_orejs = undefined, _account = undefined) {
+function mockGetAccount(_orejs = undefined, _account = {}) {
   const mockupAccount = jest.fn();
 
-  const getAccount = _account || JSON.parse(mockAccount()[0])[0];
+  const getAccount = JSON.parse(mockAccount(_account)[0])[0];
 
   mockupAccount.mockReturnValue(getAccount);
   const orejs = _orejs || constructOrejs();
@@ -51,10 +53,34 @@ function mockGetAccount(_orejs = undefined, _account = undefined) {
   return getAccount;
 }
 
-function mockTransaction(_orejs = undefined) {
+function mockGetBlock(_orejs = undefined, _block = {}) {
+  const mockupBlock = jest.fn();
+
+  const getBlock = JSON.parse(mockBlock(_block)[0])[0];
+
+  mockupBlock.mockReturnValue(getBlock);
+  const orejs = _orejs || constructOrejs();
+  orejs.eos.getBlock = mockupBlock;
+
+  return getBlock;
+}
+
+function mockGetInfo(_orejs = undefined, _info = {}) {
+  const mockupInfo = jest.fn();
+
+  const getInfo = JSON.parse(mockInfo(_info)[0])[0];
+
+  mockupInfo.mockReturnValue(getInfo);
+  const orejs = _orejs || constructOrejs();
+  orejs.eos.getInfo = mockupInfo;
+
+  return getInfo;
+}
+
+function mockGetTransaction(_orejs = undefined, _transaction = {}) {
   const mockupTransaction = jest.fn();
 
-  const transaction = jest.fn();
+  const transaction = mockTransaction(_transaction);
 
   mockupTransaction.mockReturnValue(transaction);
   const orejs = _orejs || constructOrejs();
@@ -67,5 +93,7 @@ module.exports = {
   constructOrejs,
   mockContract,
   mockGetAccount,
-  mockTransaction,
+  mockGetBlock,
+  mockGetInfo,
+  mockGetTransaction,
 };


### PR DESCRIPTION
Since we really care about transaction ordering, and not finality, confirmTransaction has been modified to check the head block, instead of the last irreversible block. The last irreversible block is, at the time of writing, 12 seconds behind the head block. And, once the transaction has submitted, it usually shows up in the head block, within 5 seconds. And, since transactions are rarely reversed, I think this makes the most sense, for now.